### PR TITLE
fix option bug

### DIFF
--- a/lib/src/program.dart
+++ b/lib/src/program.dart
@@ -112,8 +112,8 @@ class Program {
         .where((p) => !p.isOptional)
         .length;
     final int positionalMaxLength = allPositional.length;
-    final allNamed = method.parameters
-        .where((p) => p.isNamed);
+    final Iterable<Symbol> allNamed = method.parameters
+        .where((p) => p.isNamed).map((p) => p.simpleName);
     final bool allNamedExist = named.keys.every((s) => allNamed.contains(s));
     final bool positionalLengthIsOk =
     (positional.length <= positionalMaxLength


### PR DESCRIPTION
This seems to fix the bug with options.
see #7 

Allthough, it only parsers correctly if you use this syntax:
`program start --host=localhost`

not with this syntax:
`program start --host localhost`
